### PR TITLE
feature(PILOT-893): Add support for RDS_DB_* concatenated env vars

### DIFF
--- a/project/config.py
+++ b/project/config.py
@@ -19,6 +19,9 @@ from urllib.parse import urlparse
 
 from pydantic import BaseSettings
 from pydantic import Extra
+from pydantic import Field
+from pydantic import validator
+from pydantic.fields import ModelField
 
 
 class Settings(BaseSettings):
@@ -29,12 +32,36 @@ class Settings(BaseSettings):
     HOST: str = '127.0.0.1'
     PORT: int = 5064
 
+    RDS_DB_HOST: str = Field('127.0.0.1', env={'RDS_DB_HOST', 'OPSDB_UTILITY_HOST'})
+    RDS_DB_PORT: int = Field(6432, env={'RDS_DB_PORT', 'OPSDB_UTILITY_PORT'})
+    RDS_DB_USERNAME: str = Field('postgres', env={'RDS_DB_USERNAME', 'OPSDB_UTILITY_USERNAME'})
+    RDS_DB_PASSWORD: str = Field('pilot5kX8', env={'RDS_DB_PASSWORD', 'OPSDB_UTILITY_PASSWORD'})
+    RDS_DB_NAME: str = 'project'
     RDS_DB_URI: str = 'postgresql://postgres:pilot5kX8@127.0.0.1:6432/project'
     RDS_ECHO_SQL_QUERIES: bool = False
 
     OPEN_TELEMETRY_ENABLED: bool = False
     OPEN_TELEMETRY_HOST: str = '127.0.0.1'
     OPEN_TELEMETRY_PORT: int = 6831
+
+    @validator('RDS_DB_URI')
+    def uri_must_have_value(cls, value: str, values: dict[str, Any], field: ModelField) -> str:
+        """Make sure that `RDS_DB_URI` always has an appropriate value.
+
+        Value set for `RDS_DB_URI` always has a priority over concatenated `RDS_DB_*` values.
+        """
+
+        if value != field.default:
+            return value
+
+        db_uri = (
+            f'postgresql://{values["RDS_DB_USERNAME"]}:{values["RDS_DB_PASSWORD"]}'
+            f'@{values["RDS_DB_HOST"]}:{values["RDS_DB_PORT"]}/{values["RDS_DB_NAME"]}'
+        )
+        if db_uri != value:
+            return db_uri
+
+        return value
 
     class Config:
         env_file = '.env'


### PR DESCRIPTION
## Summary

Add support for concatenated env vars. Consider `RDS_DB_*` together with `OPSDB_UTILITY_*`

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-893

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] No

## Test Directions

Use 
```
RDS_DB_HOST
RDS_DB_PORT
RDS_DB_USERNAME
RDS_DB_PASSWORD
```
or
```
OPSDB_UTILITY_HOST
OPSDB_UTILITY_PORT
OPSDB_UTILITY_USERNAME
OPSDB_UTILITY_PASSWORD
```
in `.env` or as env variables when starting the application.